### PR TITLE
Revert "sync vm to get correct profiling result"

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_oneflow.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_oneflow.py
@@ -673,8 +673,6 @@ class OneFlowStableDiffusionPipeline(DiffusionPipeline):
 
                 # call the callback, if provided
                 if (i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0:
-                    # sync vm to get correct profiling result
-                    flow._oneflow_internal.eager.Sync()
                     progress_bar.update()
                     if callback is not None and i % callback_steps == 0:
                         callback(i, t, latents)


### PR DESCRIPTION
Reverts Oneflow-Inc/diffusers#60

> Juncheng Liu
> 用nsys profile 发现，加上 low._oneflow_internal.eager.Sync() 后，网络中两个unet之间的空隙变大了
> 
> Jianhao Zhang
> 进度条正常应该是因为有其它操作隐式触发了同步，当初进度条出问题的 diffuser commit 距离现在比较远了，在现在的 commit 上显式同步是作为一种保险。
> 看来这里是个两难的问题 :very_tired:
> 
> Juncheng Liu
> 我测试 stable diffusion v1.5 2.0 2.1 taiyi-chinese 4个模型，不加这个sync，进度条不会飞
> 
> Jianhao Zhang
> :rolling_on_the_floor_laughing: 那我来去掉吧
> 
> Jianhao Zhang
> 后续观察到问题了再开发新功能