### PR TITLE
Stable diffusion inpainting support nn.graph

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_oneflow.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_oneflow.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import inspect
 from typing import Callable, List, Optional, Union
 
@@ -33,6 +34,39 @@ from .safety_checker_oneflow import OneFlowStableDiffusionSafetyChecker as Stabl
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+class UNetGraph(torch.nn.Graph):
+    def __init__(self, unet):
+        super().__init__()
+        self.unet = unet
+        self.config.enable_cudnn_conv_heuristic_search_algo(False)
+        self.config.allow_fuse_add_to_output(True)
+
+    def build(self, latent_model_input, t, text_embeddings):
+        text_embeddings = torch._C.amp_white_identity(text_embeddings)
+        return self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
+
+
+class VaePostProcess(torch.nn.Module):
+    def __init__(self, vae) -> None:
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, latents):
+        latents = 1 / 0.18215 * latents
+        image = self.vae.decode(latents).sample
+        image = (image / 2 + 0.5).clamp(0, 1)
+        return image
+
+
+class VaeGraph(torch.nn.Graph):
+    def __init__(self, vae_post_process) -> None:
+        super().__init__()
+        self.vae_post_process = vae_post_process
+
+    def build(self, latents):
+        return self.vae_post_process(latents)
 
 
 def prepare_mask_and_masked_image(image, mask):
@@ -164,6 +198,28 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
         feature_extractor: CLIPFeatureExtractor,
         requires_safety_checker: bool = True,
     ):
+        
+        os.environ["ONEFLOW_MLIR_CSE"] = "1"
+        os.environ["ONEFLOW_MLIR_ENABLE_INFERENCE_OPTIMIZATION"] = "1"
+        os.environ["ONEFLOW_MLIR_ENABLE_ROUND_TRIP"] = "1"
+        os.environ["ONEFLOW_MLIR_FUSE_FORWARD_OPS"] = "1"
+        os.environ["ONEFLOW_MLIR_GROUP_MATMUL"] = "1"
+        os.environ["ONEFLOW_MLIR_PREFER_NHWC"] = "1"
+
+        os.environ["ONEFLOW_KERNEL_ENABLE_FUSED_CONV_BIAS"] = "1"
+        os.environ["ONEFLOW_KERNEL_ENABLE_FUSED_LINEAR"] = "1"
+
+        os.environ["ONEFLOW_KERENL_CONV_ENABLE_CUTLASS_IMPL"] = "1"
+        # NOTE: avoid overflow
+        if "upcast_attention" in unet.config and unet.config.upcast_attention:
+            os.environ["ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL"] = "0"
+        else:
+            os.environ["ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL"] = "1"
+        os.environ["ONEFLOW_KERNEL_GLU_ENABLE_DUAL_GEMM_IMPL"] = "1"
+
+        os.environ["ONEFLOW_CONV_ALLOW_HALF_PRECISION_ACCUMULATION"] = "1"
+        os.environ["ONEFLOW_MATMUL_ALLOW_HALF_PRECISION_ACCUMULATION"] = "1"
+
         super().__init__()
 
         if hasattr(scheduler.config, "steps_offset") and scheduler.config.steps_offset != 1:
@@ -242,6 +298,7 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
         )
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
         self.register_to_config(requires_safety_checker=requires_safety_checker)
+        self.init_graph_compile_cache(1)
 
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.enable_attention_slicing
     def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
@@ -549,6 +606,19 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 
+    def set_unet_graphs_cache_size(self, cache_size: int):
+        r"""
+        Set the cache size of compiled unet graphs.
+        This option is designed to control the GPU memory size.
+        Args:
+            cache_size ([`int`]):
+                New cache size, i.e., the maximum number of unet graphs.
+        """
+        logger.warning(
+            f"`set_unet_graphs_cache_size` is deprecated, please use `set_graph_compile_cache_size` instead."
+        )
+        self.set_graph_compile_cache_size(cache_size)
+
     @torch.no_grad()
     def __call__(
         self,
@@ -568,6 +638,8 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
         return_dict: bool = True,
         callback: Optional[Callable[[int, int, torch.FloatTensor], None]] = None,
         callback_steps: Optional[int] = 1,
+        compile_unet: bool = True,
+        compile_vae: bool = True,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -700,6 +772,25 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
         # 9. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline
         extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
 
+        # compile vae graph
+        if compile_vae:
+            cache_key = (height, width, num_images_per_prompt)
+            vae_post_process = VaePostProcess(self.vae)
+            vae_post_process.eval()
+            vae_post_process_graph = self.graph_compile_cache.get_graph(VaeGraph, cache_key, vae_post_process)
+            vae_post_process_graph.compile(latents)
+
+        # compile unet graph
+        if compile_unet:
+            cache_key = (height, width, num_images_per_prompt)
+            unet_graph = self.graph_compile_cache.get_graph(UNetGraph, cache_key, self.unet)
+            if unet_graph.is_compiled is False:
+                latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+                _, t = list(enumerate(self.scheduler.timesteps))[0]
+                # print("compile unet graph shape >>>>>> ", latent_model_input.shape, t.shape, text_embeddings.shape)
+                # oneflow.Size([2, 4, 64, 64]) oneflow.Size([]) oneflow.Size([2, 77, 768])
+                unet_graph.compile(latent_model_input, t, text_embeddings)
+
         # 10. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
@@ -712,7 +803,14 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
                 latent_model_input = torch.cat([latent_model_input, mask, masked_image_latents], dim=1)
 
                 # predict the noise residual
-                noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
+                if compile_unet:
+                    torch._oneflow_internal.profiler.RangePush(f"denoise-{i}-unet-graph")
+                    noise_pred = unet_graph(latent_model_input, t, text_embeddings)
+                    torch._oneflow_internal.profiler.RangePop()
+                else:
+                    # print("eager self.unet() shape >>>>>> ", latent_model_input.shape, t.shape, text_embeddings.shape)
+                    # oneflow.Size([2, 9, 64, 64]) oneflow.Size([]) oneflow.Size([2, 77, 768])
+                    noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
 
                 # perform guidance
                 if do_classifier_free_guidance:
@@ -729,7 +827,11 @@ class OneFlowStableDiffusionInpaintPipeline(DiffusionPipeline):
                         callback(i, t, latents)
 
         # 11. Post-processing
-        image = self.decode_latents(latents)
+        if compile_vae:
+            image = vae_post_process_graph(latents)
+            image = image.cpu().permute(0, 2, 3, 1).float().numpy()
+        else:
+            image = self.decode_latents(latents)
 
         # 12. Run safety checker
         image, has_nsfw_concept = self.run_safety_checker(image, device, text_embeddings.dtype)


### PR DESCRIPTION
- [x] OneFlowStableDiffusionInpaintPipeline支持nn.Graph

基于27测试50step耗时：
| framwork | 50step耗时(s)| 
| -- | -- |
| torch@1.12.1+cu113 | 3| 
| oneflow(Eager) commit:https://github.com/Oneflow-Inc/oneflow/commit/7de22e9869ded4699a996d8ff32de56478461a00 | 2 | 
| oneflow(Graph)commit:https://github.com/Oneflow-Inc/oneflow/commit/7de22e9869ded4699a996d8ff32de56478461a00 | 1 | 
