### PR TITLE
Floating-point comparison cannot be compared directly in oneflow, oth…

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_ancestral_discrete_oneflow.py
+++ b/src/diffusers/schedulers/scheduling_euler_ancestral_discrete_oneflow.py
@@ -262,7 +262,7 @@ class OneFlowEulerAncestralDiscreteScheduler(SchedulerMixin, ConfigMixin):
             timesteps = timesteps.to(original_samples.device)
 
         schedule_timesteps = self.timesteps
-        step_indices = [(schedule_timesteps == t).nonzero().item() for t in timesteps]
+        step_indices = [(torch.abs(schedule_timesteps - t) < 0.0001).nonzero().item() for t in timesteps]
 
         sigma = self.sigmas[step_indices].flatten()
         while len(sigma.shape) < len(original_samples.shape):


### PR DESCRIPTION
Floating-point comparison cannot be compared directly in oneflow, otherwise an error will occur.
```
Traceback (most recent call last):
  File "gen_image_deploy.py", line 2335, in <module>
    main(args)
  File "gen_image_deploy.py", line 2223, in main
    prev_image = process_batch(batch_data, highres_fix)[0]
  File "gen_image_deploy.py", line 2036, in process_batch
    images = ......
  File "/oneflow/python/oneflow/autograd/autograd_mode.py", line 154, in wrapper
    return func(*args, **kwargs)
  File "gen_image_deploy.py", line 729, in __call__
    latents = self.scheduler.add_noise(
  File "/diffusers/src/diffusers/schedulers/scheduling_euler_ancestral_discrete_oneflow.py", line 265, in add_noise
    step_indices = [(schedule_timesteps == t).nonzero().item() for t in timesteps]
  File "/diffusers/src/diffusers/schedulers/scheduling_euler_ancestral_discrete_oneflow.py", line 265, in <listcomp>
    step_indices = [(schedule_timesteps == t).nonzero().item() for t in timesteps]
RuntimeError: can only convert a tensor of size 1 to a Python scalar
  File "/oneflow/oneflow/api/python/utils/tensor_utils.h", line 114, in EagerLocalTensorItem
    GetItemInScalarTensor<T>(tensor)
  File "/oneflow/oneflow/core/framework/tensor_util.h", line 54, in GetItemInScalarTensor
    GetItemInScalarTensor(scalar_tensor, &scalar, sizeof(T))
  File "/oneflow/oneflow/core/framework/tensor_util.cpp", line 80, in GetItemInScalarTensor
    
Error Type: oneflow.ErrorProto.check_failed_error
```
