### PR TITLE
upadte text2img pipe

### DIFF
--- a/src/onediff/pipeline_stable_diffusion_oneflow.py
+++ b/src/onediff/pipeline_stable_diffusion_oneflow.py
@@ -744,10 +744,6 @@ class OneFlowStableDiffusionPipeline(DiffusionPipeline, GraphCacheMixin):
         if not return_dict:
             return (image, has_nsfw_concept)
 
-        with flow.mock_torch.disable():
-            import torch
-
-            assert torch.cuda.is_initialized() is False
         return StableDiffusionPipelineOutput(
             images=image, nsfw_content_detected=has_nsfw_concept
         )


### PR DESCRIPTION
删去text2img中pipe的import torch的操作，完全对其graph load第一次与后面推理的时间
https://github.com/Oneflow-Inc/oneflow/pull/10218