### PR TITLE
[Fix]  compiled OneFlow model for CUDA execution.

### DIFF
--- a/src/onediff/infer_compiler/convert_torch_to_of/register.py
+++ b/src/onediff/infer_compiler/convert_torch_to_of/register.py
@@ -212,12 +212,6 @@ def _(mod: None, verbose=False) -> None:
     return mod
 
 
-# TODO
-@torch2of.register
-def _(mod: flow.Tensor, verbose=False) -> None:
-    return mod
-
-
 @torch2of.register
 def _(mod: types.BuiltinFunctionType, verbose=False) -> None:
     if hasattr(mod, "__module__"):
@@ -236,4 +230,9 @@ def _(mod: types.BuiltinFunctionType, verbose=False) -> None:
             m = importlib.import_module(mod_name)
             return getattr(m, mod.__name__)
 
-    return default_converter(mod, *args, **kwargs)
+    return default_converter(mod, verbose)
+
+@torch2of.register
+def _(mod: torch.device, verbose=False) -> None:
+    index = mod.index if mod.index is not None else 0
+    return flow.device(mod.type, index)


### PR DESCRIPTION

```python
1.   # Compile PyTorch model to OneFlow
2.     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
3.     pytorch_model = PyTorchModel()
4.     of_model = oneflow_compile(pytorch_model, use_graph=True)
5. 
6. 
7.     # Verify conversion
8.     x = torch.randn(4, 4).to(device)
9.     pytorch_model.to(device)
10. 
11.     of_model.to(device)
```

代码第 11 行 ，如果 device 是 字符串 “cuda:0“是正常的，如果是 “torch.device" 缺少转换接口到导致  raise ValueError(f"Unsupported parameters in module.to: {arg}")

<img width="1087" alt="image" src="https://github.com/Oneflow-Inc/diffusers/assets/109639975/32cde74f-14a2-4461-8a18-d85a6f8fe678">
