### PR TITLE
downgrading the opencv2

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -4,4 +4,4 @@ transformers==4.27.1
 diffusers[torch]==0.19.3
 onediff
 chardet
-opencv-python==4.8.0.76
+opencv-python==4.8.0.74


### PR DESCRIPTION
opencv-python==4.8.0.76 版本有问题，会报错

```text
AttributeError: module 'cv2.dnn' has no attribute 'DictValue'
```

https://github.com/opencv/opencv-python/issues/884#issuecomment-1684691124