### PR TITLE
rm_ignore_upcast_arg_warning

### DIFF
--- a/src/onediff/infer_compiler/convert_torch_to_of/mock_diffusers/attention_processor_1f.py
+++ b/src/onediff/infer_compiler/convert_torch_to_of/mock_diffusers/attention_processor_1f.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import warnings
 from typing import Callable, Optional, Union
 
 import oneflow as torch
@@ -403,10 +402,6 @@ class Attention(nn.Module):
         if self.upcast_attention and parse_boolean_from_env(
             "ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL", True
         ):
-            warnings.warn(
-                f"Skip upcast in attention to to ensure performance! "
-                f"Don't worry, the accuracy is guaranteed!"
-            )
             os.environ["ONEFLOW_KERENL_FMHA_ENABLE_TRT_FLASH_ATTN_IMPL"] = "0"
         dtype = query.dtype
 


### PR DESCRIPTION
diffusers的行为是，只要pytorch支持fuse attention kernel(判断nn.functional中是否有scaled_dot_product_attention借口)，或则开启use_attention_xformers，就直接忽略了upcast参数，直接执行half计算。因此OneDiff 忽略upcast无需打印warning