### PR TITLE
add lcm lora sdxl example

### DIFF
--- a/examples/text_to_image_lcm_lora_sdxl.py
+++ b/examples/text_to_image_lcm_lora_sdxl.py
@@ -1,0 +1,92 @@
+import argparse
+from packaging import version
+import importlib.metadata
+
+from diffusers import LCMScheduler, AutoPipelineForText2Image
+
+
+def check_diffusers_version():
+    required_version = version.parse("0.22.0")
+    package_name = "diffusers"
+
+    try:
+        installed_version = version.parse(importlib.metadata.version(package_name))
+        if installed_version < required_version:
+            raise ValueError(
+                f"Installed {package_name} version ({installed_version}) is lower than required ({required_version})"
+            )
+
+    except importlib.metadata.PackageNotFoundError:
+        print(f"{package_name} is not installed")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple demo of LCM image generation.")
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="Self-portrait oil painting, a beautiful cyborg with golden hair, 8k",
+    )
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="stabilityai/stable-diffusion-xl-base-1.0",
+        help="Model id or local path to the Stable Diffusion base model.",
+    )
+    parser.add_argument(
+        "--adapter_id",
+        type=str,
+        default="latent-consistency/lcm-lora-sdxl",
+        help="Model id or local path to the LCM Lora adapter model.",
+    )
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--steps", type=int, default=4)
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="Warmup option sets the number of preliminary runs of the pipeline. These initial runs are necessary to ensure accurate performance data during testing.",
+    )
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--disable", action="store_true", help="Disable Onediff speeding up."
+    )
+    args = parser.parse_args()
+    return args
+
+
+check_diffusers_version()
+
+args = parse_args()
+
+if not args.disable:
+    from onediff.infer_compiler import oneflow_compile
+import torch
+
+pipe = AutoPipelineForText2Image.from_pretrained(
+    args.model_id, torch_dtype=torch.float16, variant="fp16"
+)
+pipe.scheduler = LCMScheduler.from_config(pipe.scheduler.config)
+pipe.to("cuda")
+
+if not args.disable:
+    pipe.unet = oneflow_compile(pipe.unet)
+
+for _ in range(args.warmup):
+    images = pipe(
+        args.prompt,
+        height=args.height,
+        width=args.width,
+        num_inference_steps=args.steps,
+    ).images
+
+torch.manual_seed(args.seed)
+
+images = pipe(
+    args.prompt, height=args.height, width=args.width, num_inference_steps=args.steps
+).images
+for i, image in enumerate(images):
+    image.save(
+        f"LCM-LoRA-{args.width}x{args.height}-seed-{args.seed}-disable-{args.disable}.png"
+    )


### PR DESCRIPTION
所有脚本运行在 3090 RTX 上

## lcm_lora_sdxl 与 原始 sdxl 对比

### 原始 sdxl

命令：

```bash
python diffusers/examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --prompt "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --warmup 1 --seed 1 --n_steps 20 --height 1024 --width 1024 --compile False
```

![image](https://github.com/Oneflow-Inc/diffusers/assets/3351623/9dc868ab-8887-4feb-9c13-c844cd4fc622)


### lcm lora sdxl

命令：

```bash
python diffusers/examples/text_to_image_lcm_lora_sdxl.py --model_id /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --prompt "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --warmup 1 --seed 1 --steps 4 --height 1024 --width 1024 --disable
```

![image](https://github.com/Oneflow-Inc/diffusers/assets/3351623/3148a136-2c3c-4e52-9948-2beaaf698606)


即使把 steps 调大，也不会有原始 sdxl 那样精致的效果：

```bash
python diffusers/examples/text_to_image_lcm_lora_sdxl.py --model_id /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --prompt "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --warmup 1 --seed 1 --steps 20 --height 1024 --width 1024 --disable
```

![image](https://github.com/Oneflow-Inc/diffusers/assets/3351623/a443faf9-2736-47ad-8940-e4e5072e6339)


## lcm_lora_sdxl 的 pytorch 与 oneflow 对比

### PyTorch

运行命令：

```bash
python diffusers/examples/text_to_image_lcm_lora_sdxl.py --model_id /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --adapter_id /share_nfs/hf_models/lcm-lora-sdxl --warmup 1 --disable --steps 4 --seed 1 --prompt "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --width 1024 --height 1024
```

速度：
```bash
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  3.88it/s]
```

图片：

![image](https://github.com/Oneflow-Inc/diffusers/assets/3351623/91b4aafd-9427-486c-92a5-b0ee9311037e)


### OneDiff

运行命令：

```bash
python diffusers/examples/text_to_image_lcm_lora_sdxl.py --model_id /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --adapter_id /share_nfs/hf_models/lcm-lora-sdxl --warmup 1  --steps
 4 --seed 1 --prompt "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --width 1024 --height 1024
```

速度：
```bash
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  6.44it/s]
```

图片：

![image](https://github.com/Oneflow-Inc/diffusers/assets/3351623/46d126b7-0bef-4354-bfdb-6100ab5ab5df)

## 结论

- lcm-sdxl-lora 的出图效果和原 sdxl 有较大差别
- onediff 可以加速 lcm-sdxl-lora（加速比约 68%）出图效果与为加速前相似