### PR TITLE
Fix vae dynamic shape & CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -57,6 +57,6 @@ jobs:
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-v1-5
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/image_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --use_multiple_resolutions True
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --height 512 --width 512 --use_multiple_resolutions True
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 benchmarks/stable_diffusion_2_unet.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
       - run: docker exec ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-2-1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,6 +56,7 @@ jobs:
       - run: nvidia-smi -L
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-v1-5
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/image_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --height 512 --width 512
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --height 512 --width 512
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 benchmarks/stable_diffusion_2_unet.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
       - run: docker exec ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-2-1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,7 +56,7 @@ jobs:
       - run: nvidia-smi -L
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-v1-5
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/image_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512 --use_multiple_resolutions True
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --height 512 --width 512 --use_multiple_resolutions True
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --use_multiple_resolutions True
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 benchmarks/stable_diffusion_2_unet.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
       - run: docker exec ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-2-1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,7 +56,7 @@ jobs:
       - run: nvidia-smi -L
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-v1-5
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/image_to_image.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512
-      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --height 512 --width 512
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_vae False --height 512 --width 512 --use_multiple_resolutions True
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_sdxl.py --base /share_nfs/hf_models/stable-diffusion-xl-base-1.0 --compile_unet False --height 512 --width 512 --use_multiple_resolutions True
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 benchmarks/stable_diffusion_2_unet.py --model_id=/share_nfs/hf_models/stable-diffusion-2-1
       - run: docker exec ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-2-1

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -89,6 +89,7 @@ for resolution in resolutions:
             output_type=OUTPUT_TYPE,
         ).images
         flow.cuda.empty_cache()
+        torch.cuda.empty_cache()
 
 # Normal SDXL run
 torch.manual_seed(args.seed)

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(512, 512), (256, 256),]
+    [(512, 512), (256, 256), (512, 256)]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(256, 256), (512, 512)]
+    [(512, 512), (512, 768), (768, 768),]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(1024, 1024), (512, 512), (768, 768), (1024, 512)]
+    [(512, 512), (768, 768), (512, 768)]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(512, 512), (768, 768), (512, 768)]
+    [(256, 256), (512, 256), (512, 512)]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -88,6 +88,7 @@ for resolution in resolutions:
             num_inference_steps=args.n_steps,
             output_type=OUTPUT_TYPE,
         ).images
+        torch.cuda.empty_cache()
         flow.cuda.empty_cache()
 
 # Normal SDXL run

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(512, 512), (512, 768), (768, 768),]
+    [(512, 512), (512, 256), (256, 256),]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -1,6 +1,6 @@
 """
 Torch run example: python examples/text_to_image_sdxl.py
-Compile to oneflow graph example: python examples/text_to_image_sdxl.py --compile
+Compile to oneflow graph example: python examples/text_to_image_sdxl.py
 """
 import os
 import argparse
@@ -29,9 +29,8 @@ parser.add_argument("--n_steps", type=int, default=30)
 parser.add_argument("--saved_image", type=str, required=False, default="sdxl-out.png")
 parser.add_argument("--warmup", type=int, default=1)
 parser.add_argument("--seed", type=int, default=1)
-parser.add_argument(
-    "--compile", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True
-)
+parser.add_argument("--compile_unet", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True)
+parser.add_argument("--compile_vae", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True)
 args = parser.parse_args()
 
 # Normal SDXL pipeline init.
@@ -49,10 +48,15 @@ base = StableDiffusionXLPipeline.from_pretrained(
 base.to("cuda")
 
 # Compile unet with oneflow
-if args.compile:
-    print("unet is compiled to oneflow.")
+if args.compile_unet:
+    print("Compiling unet with oneflow.")
     rewrite_self_attention(base.unet)
     base.unet = oneflow_compile(base.unet)
+
+# Compile vae with oneflow
+if args.compile_vae:
+    print("Compiling vae with oneflow.")
+    base.vae = oneflow_compile(base.vae)
 
 # Warmup
 for i in range(args.warmup):

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -88,6 +88,7 @@ for resolution in resolutions:
             num_inference_steps=args.n_steps,
             output_type=OUTPUT_TYPE,
         ).images
+        flow.cuda.empty_cache()
 
 # Normal SDXL run
 torch.manual_seed(args.seed)

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(512, 512), (512, 256), (256, 256),]
+    [(512, 512), (256, 256),]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(256, 256), (512, 256), (512, 512)]
+    [(256, 256), (512, 512)]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )
@@ -88,7 +88,6 @@ for resolution in resolutions:
             num_inference_steps=args.n_steps,
             output_type=OUTPUT_TYPE,
         ).images
-        torch.cuda.empty_cache()
         flow.cuda.empty_cache()
 
 # Normal SDXL run

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -88,8 +88,6 @@ for resolution in resolutions:
             num_inference_steps=args.n_steps,
             output_type=OUTPUT_TYPE,
         ).images
-        flow.cuda.empty_cache()
-        torch.cuda.empty_cache()
 
 # Normal SDXL run
 torch.manual_seed(args.seed)

--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -73,7 +73,7 @@ if args.compile_vae:
 
 # Define multiple resolutions for warmup
 resolutions = (
-    [(512, 512), (256, 256), (512, 256)]
+    [(512, 512), (256, 256), ]
     if args.use_multiple_resolutions
     else [(args.height, args.width)]
 )


### PR DESCRIPTION
## This PR is done:
Run:
```
export ONEFLOW_RUN_GRAPH_BY_VM="1"
python examples/text_to_image_sdxl.py --base=/share_nfs/hf_models/stable-diffusion-xl-base-1.0
```
修改 text_to_image_sdxl.py 脚本支持测试多分辨率：
```
# Compile unet with oneflow
if args.compile:
    print("unet is compiled to oneflow.")
    rewrite_self_attention(base.unet)
    base.unet = oneflow_compile(base.unet)
    base.vae = oneflow_compile(base.vae)

# Define multiple resolutions for warmup
resolutions = [(1024, 1024), (512, 512), (768, 768), (1024, 512)]

# Warmup with multiple resolutions
for resolution in resolutions:
    for i in range(args.warmup):
        image = base(
            prompt=args.prompt,
            height=resolution[0],
            width=resolution[1],
            num_inference_steps=args.n_steps,
            output_type=output_type,
        ).images
```

检查了 transformer_2d_oflow.py 已经支持了动态 shape，但是 attention_processor_oflow.py 中有些地方没有处理，这个 PR fixed。

Output:
![image](https://github.com/Oneflow-Inc/diffusers/assets/54010254/46032243-67dc-4d8e-9cdf-d8422bdb1797)
****

上面是 slicon 的，community 待测试。