### PR TITLE
[fix] unsupported operand type(s) for -: DummyModule and DummyModule

### DIFF
--- a/src/onediff/infer_compiler/utils/patch_for_compiler.py
+++ b/src/onediff/infer_compiler/utils/patch_for_compiler.py
@@ -103,3 +103,4 @@ flow.cuda.current_device = FakeCuda.current_device
 flow.cuda.mem_get_info = FakeCuda.mem_get_info
 flow.nn.functional.scaled_dot_product_attention = FakeCuda.scaled_dot_product_attention
 F.scaled_dot_product_attention = FakeCuda.scaled_dot_product_attention
+flow.cuda.memory_stats = torch.cuda.memory_stats


### PR DESCRIPTION
fix "unsupported operand type(s) for -: 'DummyModule' and 'DummyModule'")