### PR TITLE
fix_oneflow_mock

### DIFF
--- a/src/onediff/infer_compiler/import_tools/mock_torch_context.py
+++ b/src/onediff/infer_compiler/import_tools/mock_torch_context.py
@@ -14,16 +14,9 @@ def onediff_mock_torch():
         restore_funcs.append(lambda: setattr(flow, attr_name, orig_flow_attr))
         setattr(flow, attr_name, getattr(torch, attr_name))
 
-    backup = sys.modules.copy()
-
     # https://docs.oneflow.org/master/cookies/oneflow_torch.html
     with flow.mock_torch.enable(lazy=True):
         yield
 
     for restore_func in restore_funcs:
         restore_func()
-
-    # https://docs.python.org/3/library/sys.html?highlight=sys%20modules#sys.modules
-    need_backup = len(sys.modules.copy()) != len(backup)
-    if need_backup:
-        sys.modules = backup


### PR DESCRIPTION
```python
CUDA_VISIBLE_DEVICES=6 ONEDIFF_DEBUG=1 python examples/text_to_image_controlnet.py \
--controlnet  /share_nfs/hf_models/sd-controlnet-canny \
--base /share_nfs/hf_models/stable-diffusion-v1-5/ --input_image input_image_vermeer.png 
```

<details>
<summary> Output </summary>

```shell
(dev_comfy) fengwen@oneflow-28:~/packages/diffusers$ CUDA_VISIBLE_DEVICES=6 ONEDIFF_DEBUG=1 python examples/text_to_image_controlnet.py --controlnet  /share_nfs/hf_models/sd-controlnet-canny  --base /share_nfs/hf_models/stable-diffusion-v1-5/ --input_image input_image_vermeer.png 
Loading pipeline components...:   0%|                                      | 0/7 [00:00<?, ?it/s]`text_config_dict` is provided which will be used to initialize `CLIPTextConfig`. The value `text_config["id2label"]` will be overriden.
Loading pipeline components...: 100%|██████████████████████████████| 7/7 [00:01<00:00,  6.66it/s]
DEBUG [2023-12-01 08:08:04] - Test import mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17 success
/data/home/fengwen/miniconda3/envs/dev_comfy/lib/python3.10/site-packages/oneflow/_dynamo/__init__.py:30: UserWarning: The oneflow._dynamo.allow_in_graph interface is just to align the torch._dynamo.allow_in_graph interface and has no practical significance.
  warnings.warn(
DEBUG [2023-12-01 08:08:04] - Updated class proxies: len(class_proxy_dict)=1
{'mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17.models.attention_processor.Attention': <class 'register_diffusers.attention_processor_oflow.Attention'>}

DEBUG [2023-12-01 08:08:04] - Updated class proxies: len(class_proxy_dict)=1
{'mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17.models.attention_processor.AttnProcessor2_0': <class 'register_diffusers.attention_processor_oflow.AttnProcessor'>}

DEBUG [2023-12-01 08:08:04] - Updated class proxies: len(class_proxy_dict)=1
{'mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17.models.attention_processor.LoRAAttnProcessor2_0': <class 'register_diffusers.attention_processor_oflow.LoRAAttnProcessor2_0'>}

DEBUG [2023-12-01 08:08:04] - Updated class proxies: len(class_proxy_dict)=1
{'mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17.models.transformer_2d.Transformer2DModel': <class 'register_diffusers.transformer_2d_oflow.Transformer2DModel'>}

INFO [2023-12-01 08:08:04] - Failed to register_diffusers_quant e=ModuleNotFoundError("No module named 'diffusers_quant'")
Warmup
  0%|                                                                     | 0/30 [00:00<?, ?it/s]DEBUG [2023-12-01 08:08:05] - Convert <class 'diffusers.models.controlnet.ControlNetModel'> ...
INFO [2023-12-01 08:08:05] - instance_name: AttnProcessor2_0 transformed to  <class 'register_diffusers.attention_processor_oflow.AttnProcessor'>
DEBUG [2023-12-01 08:08:05] - Convert id(self._torch_module)=140285492784016 done!
DEBUG [2023-12-01 08:08:19] - Convert <class 'diffusers.models.unet_2d_condition.UNet2DConditionModel'> ...
DEBUG [2023-12-01 08:08:19] - Convert id(self._torch_module)=140282961110320 done!
100%|████████████████████████████████████████████████████████████| 30/30 [00:33<00:00,  1.12s/it]
DEBUG [2023-12-01 08:08:38] - Convert <class 'diffusers.models.autoencoder_kl.AutoencoderKL'> ...
DEBUG [2023-12-01 08:08:39] - Convert id(self._torch_module)=140285743199040 done!
Run
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:01<00:00, 26.45it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:01<00:00, 27.88it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:01<00:00, 27.90it/s]
INFO [2023-12-01 08:08:55] - Cleaning up mock files...
DEBUG [2023-12-01 08:08:55] - Removing path=PosixPath('tmp/.mock_cache/mock_diffusers_oflow_3770425_1701418084_f5511242dbcf42139407cbf5fd1cda17')
```
</details.